### PR TITLE
feat: 아이디어 마켓 - 결제페이지 ui 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { Test } from './pages/test/Test';
 import { Layout } from './pages/layout/Layout';
 import { IdeaMarket } from './pages/idea-market/IdeaMarket';
+import IdeaMarketPayment from './pages/idea-market/IdeaMarketPayment/IdeaMarketPayment';
 import { RequestAssign } from './pages/request-assign/RequestAssign';
 import { Collaboration } from './pages/collaboration/Collaboration';
 
@@ -17,6 +18,10 @@ function App() {
           <Route
             path='/idea-market'
             element={<IdeaMarket />}
+          />
+          <Route
+            path='/idea-market/payment'
+            element={<IdeaMarketPayment />}
           />
           <Route
             path='/request-assign'

--- a/src/assets/icons/Ellipse_blue.svg
+++ b/src/assets/icons/Ellipse_blue.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle id="Ellipse 77" cx="16" cy="16" r="16" fill="#377FF8"/>
+</svg>

--- a/src/assets/icons/Ellipse_gray.svg
+++ b/src/assets/icons/Ellipse_gray.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle id="Ellipse 77" cx="16" cy="16" r="16" fill="#BDBDBD"/>
+</svg>

--- a/src/assets/icons/Ellipse_white.svg
+++ b/src/assets/icons/Ellipse_white.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle id="Ellipse 77" cx="16" cy="16" r="16" fill="#ffffff"/>
+</svg>

--- a/src/assets/icons/check-light-blue.svg
+++ b/src/assets/icons/check-light-blue.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g id="iconamoon:check-light">
-<path id="Vector" d="M20 7L10 17L5 12" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector" d="M20 7L10 17L5 12" stroke="#377FF8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </g>
 </svg>

--- a/src/assets/icons/check-light-gray.svg
+++ b/src/assets/icons/check-light-gray.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g id="iconamoon:check-light">
-<path id="Vector" d="M20 7L10 17L5 12" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector" d="M20 7L10 17L5 12" stroke="#BDBDBD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </g>
 </svg>

--- a/src/assets/icons/check-light.svg
+++ b/src/assets/icons/check-light.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="iconamoon:check-light">
+<path id="Vector" d="M20 7L10 17L5 12" stroke="#BDBDBD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/components/button/PaymentButton.module.scss
+++ b/src/components/button/PaymentButton.module.scss
@@ -1,0 +1,27 @@
+.paymentButton {
+    margin-top: 45px;
+    margin-bottom: 45px;
+    width: 950px;
+    height: 75px;
+    flex-shrink: 0;
+    border-radius: 10px;
+    font-family: Pretendard, sans-serif;
+    font-size: 32px;
+    font-weight: 600;
+    letter-spacing: -0.32px;
+    text-align: center;
+    cursor: pointer;
+    border: none;
+    transition: background 0.3s;
+  
+    &.active {
+      background: #377ff8;
+      color: var(--Grey-Grey-50, #fafafa);
+    }
+  
+    &.disabled {
+      background: #bdbdbd;
+      color: var(--Grey-Grey-400, #e0e0e0);
+      cursor: not-allowed;
+    }
+  }

--- a/src/components/button/PaymentButton.tsx
+++ b/src/components/button/PaymentButton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styles from './PaymentButton.module.scss';
+
+interface PaymentButtonProps {
+  isPaymentReady: boolean;
+  onPaymentClick: () => void;
+}
+
+const PaymentButton: React.FC<PaymentButtonProps> = ({
+  isPaymentReady,
+  onPaymentClick,
+}) => {
+  return (
+    <button
+      className={`${styles.paymentButton} ${
+        isPaymentReady ? styles.active : styles.disabled
+      }`}
+      onClick={onPaymentClick}
+      disabled={!isPaymentReady}>
+      결제하기
+    </button>
+  );
+};
+
+export default PaymentButton;

--- a/src/components/info/SellerInfo.module.scss
+++ b/src/components/info/SellerInfo.module.scss
@@ -1,0 +1,46 @@
+.sellerInfo {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    .title {
+        margin-top: 45px;
+        font-size: 32px;
+        font-weight: 600;
+    }
+    .infoBox {
+        margin-top: 45px;
+        display: flex;
+        width: 950px;
+        padding: 30px 45px;
+        justify-content: space-between;
+        align-items: center;
+        border-radius: 5px;
+        border: 1px solid var(--Grey-Grey-400, #bdbdbd);
+        //background: var(--Grey-Grey-50, #fafafa);
+    }
+
+    .profile {
+        width: 100px;
+        height: 100px;
+        flex-shrink: 0;
+        background-color: #d9d9d9;
+        border-radius: 50%;
+    }
+  
+    .name {
+        font-size: 32px;
+        font-weight: 600;
+    }
+  
+    .email {
+        width: 399px;
+        flex-shrink: 0;
+        color: var(--Grey-Grey-500, #9e9e9e);
+        text-align: right;
+        font-size: 32px;
+        font-weight: 400;
+        letter-spacing: -0.32px;
+        line-height: normal;
+    }
+  }

--- a/src/components/info/SellerInfo.tsx
+++ b/src/components/info/SellerInfo.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import styles from './SellerInfo.module.scss';
+
+const SellerInfo: React.FC = () => {
+  return (
+    <div className={styles.sellerInfo}>
+      <div className={styles.title}>판매자 정보</div>
+      <div className={styles.infoBox}>
+        <div className={styles.profile}></div>
+        <div className={styles.name}>SEOYEON</div>
+        <div className={styles.email}>erwer@naver.com</div>
+      </div>
+    </div>
+  );
+};
+
+export default SellerInfo;

--- a/src/components/payment/PaymentMethods.module.scss
+++ b/src/components/payment/PaymentMethods.module.scss
@@ -45,4 +45,9 @@
             background: var(--Grey-Grey-200, #e0e0e0);
         }
         }
+        .selected {
+            background-color: #f0f0f0;
+            color:  var(--Grey-Grey-900, #222);
+            border-color: #f0f0f0;
+        }
     }

--- a/src/components/payment/PaymentMethods.module.scss
+++ b/src/components/payment/PaymentMethods.module.scss
@@ -1,0 +1,48 @@
+.paymentMethods {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    .title {
+        margin-top: 45px;
+        color: var(--Grey-Grey-900, #222);
+        font-size: 32px;
+        font-weight: 600;
+        letter-spacing: -0.32px;
+        }
+    
+        .buttonContainer {
+            margin-top: 45px;
+            display: flex;
+            gap: 16px;
+            width: 950px;
+            height: 90px;
+            flex-shrink: 0;
+        }
+    
+        .button {
+            width: 300px;
+            height: 90px;
+            flex-shrink: 0;
+            border-radius: 5px;
+            border: 1px solid var(--Grey-Grey-400, #bdbdbd);
+            //background: var(--Grey-Grey-50, #fafafa);
+            background-color: white;
+            color: var(--Grey-Grey-500, #9e9e9e);
+            font-size: 28px;
+            font-weight: 600;
+            letter-spacing: -0.28px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            cursor: pointer;
+    
+        &:hover {
+            background: var(--Grey-Grey-100, #f0f0f0);
+        }
+    
+        &:active {
+            background: var(--Grey-Grey-200, #e0e0e0);
+        }
+        }
+    }

--- a/src/components/payment/PaymentMethods.tsx
+++ b/src/components/payment/PaymentMethods.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import styles from './PaymentMethods.module.scss';
+
+const PaymentMethods: React.FC = () => {
+  return (
+    <div className={styles.paymentMethods}>
+      <div className={styles.title}>결제 수단</div>
+      <div className={styles.buttonContainer}>
+        <button className={styles.button}>카카오페이</button>
+        <button className={styles.button}>휴대폰 결제</button>
+        <button className={styles.button}>계좌이체</button>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentMethods;

--- a/src/components/payment/PaymentMethods.tsx
+++ b/src/components/payment/PaymentMethods.tsx
@@ -1,14 +1,38 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './PaymentMethods.module.scss';
 
 const PaymentMethods: React.FC = () => {
+  const [selectedMethod, setSelectedMethod] = useState<string | null>(null);
+
+  const handleButtonClick = (method: string) => {
+    setSelectedMethod(method);
+  };
+
   return (
     <div className={styles.paymentMethods}>
       <div className={styles.title}>결제 수단</div>
       <div className={styles.buttonContainer}>
-        <button className={styles.button}>카카오페이</button>
-        <button className={styles.button}>휴대폰 결제</button>
-        <button className={styles.button}>계좌이체</button>
+        <button
+          className={`${styles.button} ${
+            selectedMethod === '카카오페이' ? styles.selected : ''
+          }`}
+          onClick={() => handleButtonClick('카카오페이')}>
+          카카오페이
+        </button>
+        <button
+          className={`${styles.button} ${
+            selectedMethod === '휴대폰 결제' ? styles.selected : ''
+          }`}
+          onClick={() => handleButtonClick('휴대폰 결제')}>
+          휴대폰 결제
+        </button>
+        <button
+          className={`${styles.button} ${
+            selectedMethod === '계좌이체' ? styles.selected : ''
+          }`}
+          onClick={() => handleButtonClick('계좌이체')}>
+          계좌이체
+        </button>
       </div>
     </div>
   );

--- a/src/components/payment/PaymentSummary.module.scss
+++ b/src/components/payment/PaymentSummary.module.scss
@@ -1,0 +1,185 @@
+.paymentSummary {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+.title {
+    margin-top: 45px;
+    align-self: flex-start; 
+    color: var(--Grey-Grey-900, #222);
+    font-size: 32px;
+    font-weight: 600;
+    letter-spacing: -0.32px;
+}
+
+.summaryBox {
+    margin-top: 45px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 950px;
+    padding: 30px 45px;
+    border-radius: 5px;
+    border: 1px solid var(--Grey-Grey-400, #bdbdbd);
+    //background: var(--Grey-Grey-50, #fafafa);
+}
+
+.line {
+    width: 100%;
+    height: 1px;
+    background: #9e9e9e;
+}
+
+.row {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.label {
+    color: var(--Grey-Grey-700, #616161);
+    font-size: 28px;
+    font-weight: 500;
+    letter-spacing: -0.28px;
+}
+
+.value {
+    width: 200px;
+    text-align: right;
+    color: var(--Grey-Grey-700, #616161);
+    font-size: 28px;
+    font-weight: 500;
+    letter-spacing: -0.28px;
+}
+
+.total {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+}
+
+.totalLabel {
+    color: #616161;
+    font-size: 28px;
+    font-weight: 500;
+    letter-spacing: -0.28px;
+
+.highlight {
+    color: #377ff8;
+    }
+}
+
+.totalValue {
+    color: #377ff8;
+    font-size: 28px;
+    font-weight: 500;
+    letter-spacing: -0.28px;
+}
+
+
+.agreementBox {
+    width: 950px;
+    background: #ffffff;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.agreementTitle {
+    margin-top: 45px;
+    margin-bottom: 15px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--Grey-Grey-900, #222);
+    font-size: 28px;
+    font-weight: 600;
+    letter-spacing: -0.28px;
+    }
+
+.agreementRow {
+display: flex;
+justify-content: space-between;
+align-items: center;
+padding: 8px 0;
+}
+
+.agreementLabel {
+    flex: 1;
+    color: var(--Grey-Grey-600, #757575);
+    font-size: 24px;
+    font-weight: 400;
+    letter-spacing: -0.24px;
+}
+
+.details {
+    flex-shrink: 0;
+    color: var(--Grey-Grey-700, #616161);
+    font-size: 24px;
+    font-weight: 400;
+    letter-spacing: -0.24px;
+    margin-left: 16px;
+}
+
+.checkIcon {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    margin-right: 12px;
+    cursor: pointer;
+    fill: var(--Grey-Grey-400, #bdbdbd);
+}
+
+    .checkIcon.active {
+        fill: #377ff8;
+    }
+}
+
+.checkButton {
+    width: 40px;
+    height: 40px;
+    border: none;
+    background: none;
+    padding: 0;
+    cursor: pointer;
+    position: relative;
+  
+    &.default {
+      background-color: transparent;
+    }
+  
+    &.active {
+      background-color: transparent;
+    }
+  
+    &.circle {
+      background-color: #bdbdbd; /* 원형 배경 */
+      border-radius: 50%;
+    }
+  
+    &.circle.active {
+      background-color: #377ff8; /* 활성화된 원형 배경 */
+    }
+  
+    svg {
+      width: 24px;
+      height: 24px;
+  
+      .check {
+        stroke: #fff; /* 체크 색상 */
+        fill: none;
+      }
+  
+      .checkLine {
+        stroke: #bdbdbd; /* 비활성 체크 색상 */
+        fill: none;
+      }
+  
+      .checkLine.active {
+        stroke: #377ff8; /* 활성 체크 색상 */
+      }
+    }
+  }
+  

--- a/src/components/payment/PaymentSummary.module.scss
+++ b/src/components/payment/PaymentSummary.module.scss
@@ -21,7 +21,6 @@
     padding: 30px 45px;
     border-radius: 5px;
     border: 1px solid var(--Grey-Grey-400, #bdbdbd);
-    //background: var(--Grey-Grey-50, #fafafa);
 }
 
 .line {
@@ -100,10 +99,10 @@
     }
 
 .agreementRow {
-display: flex;
-justify-content: space-between;
-align-items: center;
-padding: 8px 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 0;
 }
 
 .agreementLabel {
@@ -123,63 +122,56 @@ padding: 8px 0;
     margin-left: 16px;
 }
 
+.checkBackground {
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+}
+
+.nonecheckBackground {
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+}
+
+
 .checkIcon {
+    position: absolute;
     flex-shrink: 0;
     width: 24px;
     height: 24px;
     margin-right: 12px;
     cursor: pointer;
+    margin-left: 4px;
+    margin-top: 4px;
     fill: var(--Grey-Grey-400, #bdbdbd);
 }
+
 
     .checkIcon.active {
         fill: #377ff8;
     }
 }
 
+.agreementTitle,
+.agreementRow {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.details {
+    cursor: pointer;
+    color: #616161;
+    font-size: 14px;
+}
+
 .checkButton {
-    width: 40px;
-    height: 40px;
+    width: 32px;
+    height: 32px;
     border: none;
     background: none;
     padding: 0;
     cursor: pointer;
     position: relative;
-  
-    &.default {
-      background-color: transparent;
-    }
-  
-    &.active {
-      background-color: transparent;
-    }
-  
-    &.circle {
-      background-color: #bdbdbd; /* 원형 배경 */
-      border-radius: 50%;
-    }
-  
-    &.circle.active {
-      background-color: #377ff8; /* 활성화된 원형 배경 */
-    }
-  
-    svg {
-      width: 24px;
-      height: 24px;
-  
-      .check {
-        stroke: #fff; /* 체크 색상 */
-        fill: none;
-      }
-  
-      .checkLine {
-        stroke: #bdbdbd; /* 비활성 체크 색상 */
-        fill: none;
-      }
-  
-      .checkLine.active {
-        stroke: #377ff8; /* 활성 체크 색상 */
-      }
-    }
-  }
-  
+}

--- a/src/components/payment/PaymentSummary.tsx
+++ b/src/components/payment/PaymentSummary.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import React, { useState } from 'react';
 import styles from './PaymentSummary.module.scss';
-import EllipseGray from '../../assets/icons/ellipse_gray.svg';
-import EllipseBlue from '../../assets/icons/ellipse_blue.svg';
-import EllipseWhite from '../../assets/icons/ellipse_white.svg';
+import EllipseGray from '../../assets/icons/Ellipse_gray.svg';
+import EllipseBlue from '../../assets/icons/Ellipse_blue.svg';
+import EllipseWhite from '../../assets/icons/Ellipse_white.svg';
 import CheckLightIcon from '../../assets/icons/check-light.svg';
 import CheckLightGray from '../../assets/icons/check-light-gray.svg';
 import CheckLightBlue from '../../assets/icons/check-light-blue.svg';

--- a/src/components/payment/PaymentSummary.tsx
+++ b/src/components/payment/PaymentSummary.tsx
@@ -1,5 +1,12 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import React, { useState } from 'react';
 import styles from './PaymentSummary.module.scss';
+import EllipseGray from '../../assets/icons/ellipse_gray.svg';
+import EllipseBlue from '../../assets/icons/ellipse_blue.svg';
+import EllipseWhite from '../../assets/icons/ellipse_white.svg';
+import CheckLightIcon from '../../assets/icons/check-light.svg';
+import CheckLightGray from '../../assets/icons/check-light-gray.svg';
+import CheckLightBlue from '../../assets/icons/check-light-blue.svg';
 
 const PaymentSummary: React.FC = () => {
   const [isAllAgreed, setIsAllAgreed] = useState(false);
@@ -17,6 +24,7 @@ const PaymentSummary: React.FC = () => {
     setAgreements(newAgreements);
     setIsAllAgreed(newAgreements.every((value) => value));
   };
+
   return (
     <div className={styles.paymentSummary}>
       <div className={styles.title}>결제 금액</div>
@@ -42,31 +50,16 @@ const PaymentSummary: React.FC = () => {
         <div
           className={styles.agreementTitle}
           onClick={handleAllAgree}>
-          <button
-            type='button'
-            className={`${styles.checkButton} ${
-              isAllAgreed ? styles.active : styles.default
-            }`}>
-            <svg
-              className={styles.checkIcon}
-              width='24'
-              height='24'
-              viewBox='0 0 24 24'
-              xmlns='http://www.w3.org/2000/svg'>
-              <circle
-                cx='12'
-                cy='12'
-                r='12'
-                className={styles.circle}
-              />
-              {isAllAgreed && (
-                <path
-                  d='M8 12l2 2 4-4'
-                  className={styles.check}
-                />
-              )}
-            </svg>
-          </button>
+          <img
+            src={CheckLightIcon}
+            alt='체크 아이콘'
+            className={styles.checkIcon}
+          />
+          <img
+            src={isAllAgreed ? EllipseBlue : EllipseGray}
+            alt='전체 동의 체크 배경'
+            className={styles.checkBackground}
+          />
           아래 약관에 전체 동의해요
         </div>
 
@@ -74,36 +67,22 @@ const PaymentSummary: React.FC = () => {
           '‘BrainPIX’ 서비스 이용약관 동의 (필수)',
           '개인정보 수집 및 이용 동의 (필수)',
           '개인정보 제3자 제공 동의 (필수)',
-        ].map((label: string, index: number) => (
+        ].map((label, index) => (
           <div
             key={index}
-            className={styles.agreementRow}>
-            <button
-              type='button'
-              className={`${styles.checkButton} ${
-                agreements[index] ? styles.active : styles.default
-              }`}
-              onClick={() => handleAgreementClick(index)}>
-              <svg
-                className={styles.checkIcon}
-                width='24'
-                height='24'
-                viewBox='0 0 24 24'
-                xmlns='http://www.w3.org/2000/svg'>
-                <circle
-                  cx='12'
-                  cy='12'
-                  r='12'
-                  className={styles.circle}
-                />
-                {agreements[index] && (
-                  <path
-                    d='M8 12l2 2 4-4'
-                    className={styles.check}
-                  />
-                )}
-              </svg>
-            </button>
+            className={styles.agreementRow}
+            onClick={() => handleAgreementClick(index)}>
+            <img
+              src={EllipseWhite}
+              alt='개별 동의 체크 배경'
+              className={styles.nonecheckBackground}
+              onClick={() => handleAgreementClick(index)}
+            />
+            <img
+              src={agreements[index] ? CheckLightBlue : CheckLightGray}
+              alt='체크 아이콘'
+              className={styles.checkIcon}
+            />
             <span className={styles.agreementLabel}>{label}</span>
             <span
               className={styles.details}

--- a/src/components/payment/PaymentSummary.tsx
+++ b/src/components/payment/PaymentSummary.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import styles from './PaymentSummary.module.scss';
+
+const PaymentSummary: React.FC = () => {
+  const [isAllAgreed, setIsAllAgreed] = useState(false);
+  const [agreements, setAgreements] = useState([false, false, false]);
+
+  const handleAllAgree = () => {
+    const newState = !isAllAgreed;
+    setIsAllAgreed(newState);
+    setAgreements(agreements.map(() => newState));
+  };
+
+  const handleAgreementClick = (index: number) => {
+    const newAgreements = [...agreements];
+    newAgreements[index] = !newAgreements[index];
+    setAgreements(newAgreements);
+    setIsAllAgreed(newAgreements.every((value) => value));
+  };
+  return (
+    <div className={styles.paymentSummary}>
+      <div className={styles.title}>결제 금액</div>
+      <div className={styles.summaryBox}>
+        <div className={styles.row}>
+          <div className={styles.label}>주문 금액</div>
+          <div className={styles.value}>2,000,000원</div>
+        </div>
+        <div className={styles.row}>
+          <div className={styles.label}>수수료</div>
+          <div className={styles.value}>10,000원</div>
+        </div>
+        <div className={styles.line}></div>
+        <div className={styles.row}>
+          <div className={styles.totalLabel}>
+            총 결제 금액 <span className={styles.highlight}>(VAT 포함)</span>
+          </div>
+          <div className={styles.totalValue}>2,010,000원</div>
+        </div>
+      </div>
+
+      <div className={styles.agreementBox}>
+        <div
+          className={styles.agreementTitle}
+          onClick={handleAllAgree}>
+          <button
+            type='button'
+            className={`${styles.checkButton} ${
+              isAllAgreed ? styles.active : styles.default
+            }`}>
+            <svg
+              className={styles.checkIcon}
+              width='24'
+              height='24'
+              viewBox='0 0 24 24'
+              xmlns='http://www.w3.org/2000/svg'>
+              <circle
+                cx='12'
+                cy='12'
+                r='12'
+                className={styles.circle}
+              />
+              {isAllAgreed && (
+                <path
+                  d='M8 12l2 2 4-4'
+                  className={styles.check}
+                />
+              )}
+            </svg>
+          </button>
+          아래 약관에 전체 동의해요
+        </div>
+
+        {[
+          '‘BrainPIX’ 서비스 이용약관 동의 (필수)',
+          '개인정보 수집 및 이용 동의 (필수)',
+          '개인정보 제3자 제공 동의 (필수)',
+        ].map((label: string, index: number) => (
+          <div
+            key={index}
+            className={styles.agreementRow}>
+            <button
+              type='button'
+              className={`${styles.checkButton} ${
+                agreements[index] ? styles.active : styles.default
+              }`}
+              onClick={() => handleAgreementClick(index)}>
+              <svg
+                className={styles.checkIcon}
+                width='24'
+                height='24'
+                viewBox='0 0 24 24'
+                xmlns='http://www.w3.org/2000/svg'>
+                <circle
+                  cx='12'
+                  cy='12'
+                  r='12'
+                  className={styles.circle}
+                />
+                {agreements[index] && (
+                  <path
+                    d='M8 12l2 2 4-4'
+                    className={styles.check}
+                  />
+                )}
+              </svg>
+            </button>
+            <span className={styles.agreementLabel}>{label}</span>
+            <span
+              className={styles.details}
+              onClick={() => handleAgreementClick(index)}>
+              자세히
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PaymentSummary;

--- a/src/components/payment/PaymentTitle.module.scss
+++ b/src/components/payment/PaymentTitle.module.scss
@@ -1,0 +1,42 @@
+.title {
+    margin-top: 45px;
+    font-size: 32px;
+    font-weight: 600;
+    margin-bottom: 16px;
+}
+
+.content {
+    margin-top: 45px;
+    display: flex;
+    justify-items: left; 
+    margin-left: 30px;
+    gap: 16px;
+    width: 920px;
+    height: 195px;
+    flex-shrink: 0;
+    border-bottom: 1px solid #9E9E9E;
+    padding-bottom: 16px;
+}
+
+.image {
+    width: 150px;
+    height: 150px;
+    background-color: #d9d9d9;
+}
+
+.text {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.price {
+    font-size: 36px;
+    font-weight: 600;
+}
+
+.description {
+    font-size: 32px;
+    font-weight: 500;
+}

--- a/src/components/payment/PaymentTitle.tsx
+++ b/src/components/payment/PaymentTitle.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styles from './PaymentTitle.module.scss';
+
+const PaymentTitle: React.FC = () => {
+  return (
+    <div className={styles.paymentTitle}>
+      <div className={styles.title}>결제하기</div>
+      <div className={styles.content}>
+        <div className={styles.image}></div>
+        <div className={styles.text}>
+          <div className={styles.price}>2,000,000원</div>
+          <div className={styles.description}>디자인 해드립니다</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentTitle;

--- a/src/pages/idea-market/IdeaMarketPayment/IdeaMarketPayment.module.scss
+++ b/src/pages/idea-market/IdeaMarketPayment/IdeaMarketPayment.module.scss
@@ -1,0 +1,9 @@
+.ideaMarketPayment {
+    padding: 0 465px; //임시 지정
+    box-sizing: border-box;
+}
+.ideaMarketPaymentLayout {
+    padding: 0 495px; //임시 지정
+    box-sizing: border-box;
+}
+

--- a/src/pages/idea-market/IdeaMarketPayment/IdeaMarketPayment.tsx
+++ b/src/pages/idea-market/IdeaMarketPayment/IdeaMarketPayment.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PaymentTitle from '../../../components/payment/PaymentTitle';
+import SellerInfo from '../../../components/info/SellerInfo';
+import PaymentMethods from '../../../components/payment/PaymentMethods';
+import PaymentSummary from '../../../components/payment/PaymentSummary';
+import PaymentButton from '../../../components/button/PaymentButton';
+import styles from './IdeaMarketPayment.module.scss';
+
+const IdeaMarketPayment: React.FC = () => {
+  return (
+    <>
+      <div className={styles.ideaMarketPayment}>
+        <PaymentTitle />
+      </div>
+      <div className={styles.ideaMarketPaymentLayout}>
+        <SellerInfo />
+        <PaymentMethods />
+        <PaymentSummary />
+        <PaymentButton
+          isPaymentReady={true}
+          onPaymentClick={() => {}}
+        />
+      </div>
+    </>
+  );
+};
+
+export default IdeaMarketPayment;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [
     svgr({
       // A minimatch pattern, or array of patterns, which specifies the files in the build the plugin should include.
-      include: '**/*.svg?react',
+      include: '**/*.svg',
     }),
     react(),
   ],


### PR DESCRIPTION
## 🚩 관련 이슈

- #https://github.com/BrainPix/BrainPix-front/issues/10

## 📋 구현 기능 명세

- [x]  결제 수단 버튼 1개만 클릭 가능
- [x]  약관 체크 버튼 활성화

## 📌 PR Point

- 현재 임의로 페이지 양쪽 패딩을 지정해뒀습니다 (495xp)

## 📸 결과물 스크린샷

1. PaymentTitle

![image](https://github.com/user-attachments/assets/d513addb-a399-4afe-bd0e-d7e00adfad6b)

2. SellerInfo

![image](https://github.com/user-attachments/assets/2361ee4d-c362-42d5-a0bc-291c8e8ca788)

3. PaymentMethods

![image](https://github.com/user-attachments/assets/8671d4b0-0583-4cf2-8041-ba598101fd5e)

4. PaymentSummary

![image](https://github.com/user-attachments/assets/863724cd-6f21-491c-8cf6-ee6cbbc1bcab)

5. PaymentButton

![image](https://github.com/user-attachments/assets/051e2e76-d7a9-41c9-9e8c-57e68aa7fc07)

IdeaMarketPayment.tsx

![image](https://github.com/user-attachments/assets/6c6a2f2e-670d-46bc-8922-a21e89f649fa)

## 🛠️ 테스트

## 🚀 API Endpoint